### PR TITLE
Add controls_transaction? method to task template

### DIFF
--- a/lib/generators/schlepper/templates/onetime_script.rb.erb
+++ b/lib/generators/schlepper/templates/onetime_script.rb.erb
@@ -1,6 +1,14 @@
 class <%= file_name.classify %> < Schlepper::Task
   attr_reader :failure_message
 
+  # Signals to the task runner that this task will control its own transaction.
+  # When true the task runner will not open a transaction.
+  # Use with caution.
+  # @return [Boolean]
+  def controls_transaction?
+    false
+  end
+
   # @return [String] A short note on what the purpose of this task is
   def description
     <<-DOC.strip_heredoc
@@ -9,7 +17,7 @@ class <%= file_name.classify %> < Schlepper::Task
     fail NotImplementedError, "Documentation has not been added for #{self.class.name}"
   end
 
-  # @return [String] The individuals that owns this task
+  # @return [String] The individual that owns this task
   def owner
     "John Bjön"
     fail NotImplementedError, "Ownership has not been claimed for #{self.class.name}"

--- a/lib/generators/schlepper/templates/onetime_script.rb.erb
+++ b/lib/generators/schlepper/templates/onetime_script.rb.erb
@@ -17,7 +17,7 @@ class <%= file_name.classify %> < Schlepper::Task
     fail NotImplementedError, "Documentation has not been added for #{self.class.name}"
   end
 
-  # @return [String] The individual that owns this task
+  # @return [String] The individuals that own this task
   def owner
     "John Bjön"
     fail NotImplementedError, "Ownership has not been claimed for #{self.class.name}"

--- a/lib/schlepper/version.rb
+++ b/lib/schlepper/version.rb
@@ -1,3 +1,3 @@
 module Schlepper
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
While `controls_transaction?` is an optional method for tasks, including it in the generated template will help remind users of this default behavior.
