### PR TITLE
[#157380720] Use ActiveRecord::Base.connection#quote

### DIFF
--- a/lib/schlepper/process.rb
+++ b/lib/schlepper/process.rb
@@ -106,7 +106,7 @@ module Schlepper
       if status
         ActiveRecord::Base.connection.execute <<-SQL
           INSERT INTO schlepper_tasks (version, owner, description, completed_at)
-          VALUES (#{task.version_number}, #{ActiveRecord::Base.sanitize(task.owner)}, #{ActiveRecord::Base.sanitize(task.description)}, #{ActiveRecord::Base.connection.quote(Time.now.to_s(:db))});
+          VALUES (#{task.version_number}, #{ActiveRecord::Base.connection.quote(task.owner)}, #{ActiveRecord::Base.connection.quote(task.description)}, #{ActiveRecord::Base.connection.quote(Time.now.to_s(:db))});
         SQL
       end
 


### PR DESCRIPTION
Replace ActiveRecord::Base#sanitize with ActiveRecord::Base.connection#quote as #sanitize is deprecated in rails5

Story Link:- https://www.pivotaltracker.com/story/show/157380720