### PR TITLE
Fix issue/22: Truncate descriptions so we don't raise in ActiveRecord on successful schleppers

### DIFF
--- a/lib/schlepper/process.rb
+++ b/lib/schlepper/process.rb
@@ -109,7 +109,7 @@ module Schlepper
           VALUES (
             #{task.version_number},
             #{ActiveRecord::Base.connection.quote(task.owner)},
-            #{ActiveRecord::Base.connection.quote(task.description.truncate(256, separator: ' '))},
+            #{ActiveRecord::Base.connection.quote(task.description.mb_chars.compose.limit(256))},
             #{ActiveRecord::Base.connection.quote(Time.now.to_s(:db))}
           );
         SQL

--- a/lib/schlepper/version.rb
+++ b/lib/schlepper/version.rb
@@ -1,3 +1,3 @@
 module Schlepper
-  VERSION = '1.0.4'
+  VERSION = '1.0.5'
 end

--- a/test/process_test.rb
+++ b/test/process_test.rb
@@ -83,7 +83,7 @@ class ProcessTest < Minitest::Test
   def test_valid_task_too_long_description_ok
     stub_rails_root_to 'valid_task_too_long_description' do
       # We're really just expecting it not to raise an exception when recording it in the DB.
-      assert_output(/wackamole/) do
+      assert_output(/wackamöle /) do
         Schlepper::Process.new.run_all
       end
     end

--- a/test/support/valid_task_too_long_description/script/schleppers/20190312142600_valid_task_too_long_description.rb
+++ b/test/support/valid_task_too_long_description/script/schleppers/20190312142600_valid_task_too_long_description.rb
@@ -1,11 +1,11 @@
 require 'active_support/core_ext/string'
 
-class MyTask < Schlepper::Task
+class LongUTF8Description < Schlepper::Task
   attr_reader :failure_message
 
   # @return [String] A short note on what the purpose of this task is
   def description
-    'wackamole ' * 26
+    'wackamöle \u1F60 ' * 26
   end
 
   # @return [String] The individuals that owns this task


### PR DESCRIPTION
Not clear why the diff is odd... but I accidently pushed an earlier version of this change onto master, and it's showing the diff against that instead of the reverted master, at least to me.